### PR TITLE
🔧(project) add potsie bridged network

### DIFF
--- a/docker-compose.edx.yml
+++ b/docker-compose.edx.yml
@@ -6,8 +6,12 @@ services:
     ports:
       - "3316:3306"
     env_file: env.d/edx
-    command: >
-      mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+    networks:
+      potsie:
+        aliases:
+          - edx_mysql
+      default:
 
   edx_mongodb:
     image: mongo:3.2
@@ -73,3 +77,8 @@ services:
 
   dockerize:
     image: jwilder/dockerize
+
+networks:
+  potsie:
+    name: potsie
+    external: true


### PR DESCRIPTION
# Purpose

mysql from edx is connected to potsie with a bridged network to use it as a datasource for grafana to get dashboard about generic metrics of the platform usage (see PR [#16](https://github.com/openfun/potsie/pull/16) of [potsie](https://github.com/openfun/potsie) repository)

# Proposal

- [x] add external bridge potsie network in edx docker-compose