### PR TITLE
🚧(project) add keycloak service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
 - Add CI configuration
 - Add edx cms service
 - Add graylog service
 - Add edx lms service
+- Add keycloak service
+
 
 [Unreleased]: https://github.com/openfun/learning-analytics-playground/commits/main

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Generated events with end-to-end tests or with manual navigation on the LMS serv
 
 3. You should see appearing a list of all the messages you have generated!
 
+## Keycloak
+
+The keycloak SSO service is pre-configured for the `fun-mooc` realm. Once
+started with the project's `make run`, it can be accessed at
+[http://localhost:8080](http://localhost:8080). Administrator credentials are:
+`admin:pass`.
+
+For now only the `potsie` client has been configured to login to grafana (see
+the [openfun/potsie](https://github.com/openfun/potsie) project) using a
+Keycloak account (it should have been created by the `make bootstrap` command).
+You can login to grafana using the following credentials: `grafana:funfunfun`.
+
 ## License
 
 This work is released under the MIT license (see [LICENSE](./LICENSE)).

--- a/bin/compose
+++ b/bin/compose
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-declare DOCKER_UID="$(id -u)"
-declare DOCKER_GID="$(id -g)"
+DOCKER_UID="$(id -u)"
+DOCKER_GID="$(id -g)"
 
-DOCKER_UID=${DOCKER_UID} \
-  DOCKER_GID=${DOCKER_GID} \
-  docker-compose \
-  -f docker-compose.yml \
-  -f docker-compose.edx.yml \
+export DOCKER_UID
+export DOCKER_GID
+
+docker-compose \
   -f docker-compose.cypress.yml \
+  -f docker-compose.edx.yml \
+  -f docker-compose.keycloak.yml \
+  -f docker-compose.yml \
   "$@"

--- a/bin/cypress
+++ b/bin/cypress
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-declare DOCKER_UID="$(id -u)"
-declare DOCKER_GID="$(id -g)"
+DOCKER_UID="$(id -u)"
+DOCKER_GID="$(id -g)"
 
-DOCKER_UID=${DOCKER_UID} \
-  DOCKER_GID=${DOCKER_GID} \
-  docker-compose \
+export DOCKER_UID
+export DOCKER_GID
+
+docker-compose \
   -f docker-compose.cypress.yml \
   run \
-  --rm cypress "${@}"
+    --rm cypress "${@}"

--- a/bin/realm
+++ b/bin/realm
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+export PATH="/opt/jboss/keycloak/bin/:${PATH}"
+
+declare realm="${DEFAULT_REALM_NAME}"
+declare user="${TEST_USER_NAME}"
+declare password="${TEST_USER_PASSWORD}"
+declare email="${TEST_USER_EMAIL}"
+declare client_id="${GRAFANA_CLIENT_ID}"
+declare client_uuid
+declare client_secret="${GRAFANA_CLIENT_SECRET}"
+
+# Server login
+kcadm.sh config credentials \
+  --server http://localhost:8080/auth \
+  --realm master \
+  --user "${KEYCLOAK_USER}" \
+  --password "${KEYCLOAK_PASSWORD}"
+
+# Delete the realm if it already exists
+if kcadm.sh get "realms/${realm}"; then
+  kcadm.sh delete "realms/${realm}"
+fi
+
+# And (re-)create it
+kcadm.sh create realms -s realm="${realm}" -s enabled=true
+
+# Create a client along with its roles
+kcadm.sh create clients -r "${realm}" -f - < /tmp/config/clients/potsie.json
+client_uuid=$(kcadm.sh get clients -r fun-mooc --fields id -q clientId=potsie --format csv | sed 's/"//g')
+kcadm.sh create "clients/${client_uuid}/roles" -r "${realm}" -s name=admin
+kcadm.sh create "clients/${client_uuid}/roles" -r "${realm}" -s name=editor
+kcadm.sh create "clients/${client_uuid}/roles" -r "${realm}" -s name=viewer
+
+# Create a new user
+kcadm.sh create users -r "${realm}" -s username="${user}" -s email="${email}" -s enabled=true
+kcadm.sh set-password -r "${realm}" --username "${user}" --new-password "${password}"

--- a/data/keycloak/clients/potsie.json
+++ b/data/keycloak/clients/potsie.json
@@ -1,0 +1,31 @@
+{
+      "clientId": "potsie",
+      "name": "Potsie",
+      "description": "Grafana-based learning analytics dashboards",
+      "enabled": true,
+      "rootUrl": "http://localhost:3000",
+      "adminUrl": "http://localhost:3000",
+      "baseUrl": "/login/generic_oauth",
+      "clientAuthenticatorType": "client-secret",
+      "secret": "fa9e98ee-61a1-4092-8dac-1597da0c1bb0",
+      "redirectUris": ["http://localhost:3000/login/generic_oauth"],
+      "webOrigins": ["http://localhost:3000/login"],
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "fullScopeAllowed": false,
+      "protocol": "openid-connect",
+      "protocolMappers": [
+        {
+          "name": "Roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "config": {
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "usermodel.clientRoleMapping.clientId": "potsie",
+            "access.token.claim": "true",
+            "multivalued": "true"
+          }
+        }
+      ]
+}

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -1,0 +1,28 @@
+version: "3.2"
+services:
+
+  keycloak:
+    image: "quay.io/keycloak/keycloak:14.0.0"
+    env_file: env.d/keycloak
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./bin:/opt/jboss/keycloak/local/bin
+      - ./data/keycloak/:/tmp/config
+    depends_on:
+      - keycloak_postgres
+    networks:
+      potsie:
+        aliases:
+          - keycloak
+      default:
+
+  keycloak_postgres:
+    image: postgres:13.3
+    env_file: env.d/keycloak
+    networks:
+      default:
+
+networks:
+  potsie:
+    external: true

--- a/env.d/keycloak
+++ b/env.d/keycloak
@@ -1,0 +1,23 @@
+# Postgresql
+POSTGRES_DB=keycloak
+POSTGRES_USER=keycloak
+POSTGRES_PASSWORD=password
+
+# Database
+DB_VENDOR=postgres
+DB_ADDR=keycloak_postgres
+DB_DATABASE=keycloak
+DB_USER=keycloak
+DB_PASSWORD=password
+
+# Admin user
+KEYCLOAK_USER=admin
+KEYCLOAK_PASSWORD=pass
+
+# Potsie
+DEFAULT_REALM_NAME=fun-mooc
+TEST_USER_NAME=grafana
+TEST_USER_PASSWORD=funfunfun
+TEST_USER_EMAIL=grafana@example.org
+GRAFANA_CLIENT_ID=potsie
+GRAFANA_CLIENT_SECRET=fa9e98ee-61a1-4092-8dac-1597da0c1bb0


### PR DESCRIPTION
## Purpose

We decided to integrate a dedicated identity provider for all our services instead of using edx as such.

## Proposal

- [x] add `keycloak*` services
- [x] ~configure `edx_lms` and `edx_cms` services as keycloak auth clients~
- [x] document the service usage
- [x] automate realm configuration/accounts loading during the project's bootstrapping

Edit: configuring a rather old edx release to authenticate using keycloak should be treated in a separated contribution.