### PR TITLE
🔧(project) decouple lms from the base stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           command: make bootstrap
       - run:
           name: Run e2e tests
-          command: make test
+          command: make run-edx && make test
 
   lint-test:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -102,15 +102,22 @@ migrate:  ## perform database migrations
 
 run: \
   tree
-run:  ## start the service
-	$(COMPOSE) up -d
+run:  ## start base services
+	$(COMPOSE) up -d graylog keycloak
+	@echo "Wait for service to be up..."
+	$(COMPOSE_RUN) dockerize -wait tcp://graylog:9000 -timeout 60s
+	$(COMPOSE_RUN) dockerize -wait tcp://keycloak:8080 -timeout 60s
+.PHONY: run
+
+run-edx: \
+  tree
+run-edx:  ## start edx services
+	$(COMPOSE) up -d edx_cms
 	@echo "Wait for service to be up..."
 	$(WAIT_DB)
 	$(COMPOSE_RUN) dockerize -wait tcp://edx_redis:6379 -timeout 60s
-	$(COMPOSE_RUN) dockerize -wait tcp://graylog:9000 -timeout 60s
 	$(COMPOSE_RUN) dockerize -wait tcp://edx_lms:8000 -timeout 60s
 	$(COMPOSE_RUN) dockerize -wait tcp://edx_cms:8000 -timeout 60s
-	$(COMPOSE_RUN) dockerize -wait tcp://keycloak:8080 -timeout 60s
 .PHONY: run
 
 realm:  ## import configured keycloak realm


### PR DESCRIPTION
## Purpose

Too many services are booted when running the project.

## Proposal

Start only base services when using the `run` Makefile target and add a dedicated rule per LMS, _e.g._ `run-edx`.
