### PR TITLE
👷(circleci) migrate to machine image stable release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,8 @@ jobs:
             test $(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com/openfun" | wc -L) -le 80
 
   test-e2e:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     working_directory: ~/fun
     steps:
       - checkout


### PR DESCRIPTION
## Purpose

CircleCI will soon deprecate default base image for the machine executor.

## Proposal

We need to explicitly switch to the latest image stable release.

For more information about this migration please, refer to the migration guide:

https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/
