### PR TITLE
✅(tests) add problem interaction tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - Add keycloak service
 - Add edX course generator
 - Add edX enrollment event tests
+- Add edX problem_check event tests
 
 
 [Unreleased]: https://github.com/openfun/learning-analytics-playground/commits/main

--- a/e2e/cypress/integration/lms_problem_interaction/checkboxes_response_hint_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/checkboxes_response_hint_spec.js
@@ -1,0 +1,70 @@
+// LMS Checkboxes Response With Hint Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Checkboxes Response With Hint Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("checkboxesResponseHint");
+  const problem = getProblem(section, "checkboxesResponseHint");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Ask for a first hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (1 sur 2) :");
+    // Input wrong answers.
+    cy.get(`#input_${problemId}_2_1_choice_0`).check();
+    cy.get(`#input_${problemId}_2_1_choice_1`).check();
+    cy.get(`#input_${problemId}_2_1_choice_2`).check();
+    cy.get(`#input_${problemId}_2_1_choice_3`).check();
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    // Ask for a first hint (again).
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (1 sur 2) :");
+    // Ask for a second hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (2 sur 2) :");
+    // Input correct answers.
+    cy.get(`#input_${problemId}_2_1_choice_0`).check();
+    cy.get(`#input_${problemId}_2_1_choice_1`).check();
+    cy.get(`#input_${problemId}_2_1_choice_2`).uncheck();
+    cy.get(`#input_${problemId}_2_1_choice_3`).check();
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log feedback_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.feedback_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log demandhint_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.demandhint_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/checkboxes_response_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/checkboxes_response_spec.js
@@ -1,0 +1,51 @@
+// LMS Checkboxes Response Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Checkboxes Response Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("checkboxesResponse");
+  const problem = getProblem(section, "checkboxesResponse");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answers.
+    cy.get(`#input_${problemId}_2_1_choice_0`).check();
+    cy.get(`#input_${problemId}_2_1_choice_1`).check();
+    cy.get(`#input_${problemId}_2_1_choice_2`).check();
+    cy.get(`#input_${problemId}_2_1_choice_3`).check();
+    cy.get(`#input_${problemId}_2_1_choice_4`).check();
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    // Input correct answers.
+    cy.get(`#input_${problemId}_2_1_choice_0`).check();
+    cy.get(`#input_${problemId}_2_1_choice_1`).uncheck();
+    cy.get(`#input_${problemId}_2_1_choice_2`).check();
+    cy.get(`#input_${problemId}_2_1_choice_3`).check();
+    cy.get(`#input_${problemId}_2_1_choice_4`).uncheck();
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/circuitschematic_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/circuitschematic_spec.js
@@ -1,0 +1,35 @@
+// LMS Circuit Schematic Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Circuit Schematic Problem Interaction Test", () => {
+  const { courseId } = Cypress.env("EDX_COURSES").demoCourse1;
+  const [section] = getSectionAndURL("circuitschematic");
+  const problem = getProblem(section, "circuitschematic");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Submit response.
+    // Note: Circuit Schematic Problems are wrapped inside a canvas element.
+    // To avoid manipulating the canvas element from cypress (which is complicated),
+    // we send the submission via a post request.
+    // This works, however we miss the problem_check and problem_graded browser events.
+    cy.request({
+      method: "POST",
+      url: `/courses/${courseId}/xblock/${problem.locator}/handler/xmodule_handler/problem_check`,
+      form: true,
+      body: {
+        [`input_${problemId}_2_1`]:
+          '[["w",[296,120,296,168]],["w",[296,168,296,184]],["w",[296,120,168,120]],["r",[168,184,0],{"r":"1","_json_":3},["1","0"]],["v",[168,120,0],{"value":"dc(1)","_json_":4},["output","1"]],["r",[296,184,0],{"r":"1","_json_":5},["output","0"]],["L",[296,168,3],{"label":"output","_json_":6},["output"]],["g",[216,232,0],{"_json_":7},["0"]],["w",[168,168,168,184]],["w",[168,232,216,232]],["w",[296,232,216,232]],["view",111.87136,75.04352,2.44140625,null,"10","1G",null,"100","1","1000"],["dc",{"0":0,"1":-0.49999999999999994,"output":0.5,"I(_4)":-0.5}]]',
+      },
+    });
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/custom_grader_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/custom_grader_spec.js
@@ -1,0 +1,55 @@
+// LMS Custom Grader Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Custom Grader Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("customgrader");
+  const problem = getProblem(section, "customgrader");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answers.
+    cy.get(`#input_${problemId}_2_1`).clear().type("100");
+    cy.get(`#input_${problemId}_2_2`).clear().type("0");
+    cy.get(`#input_${problemId}_3_1`).clear().type("100");
+    cy.get(`#input_${problemId}_3_2`).clear().type("10");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    cy.get(`#status_${problemId}_2_2`).should("contain", "incorrect");
+    cy.get(`#status_${problemId}_3_1`).should("contain", "incorrect");
+    cy.get(`#status_${problemId}_3_2`).should("contain", "incorrect");
+    // Input correct answers.
+    cy.get(`#input_${problemId}_2_1`).clear().type("10");
+    cy.get(`#input_${problemId}_2_2`).clear().type("0");
+    cy.get(`#input_${problemId}_3_1`).clear().type("10");
+    cy.get(`#input_${problemId}_3_2`).clear().type("10");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.get(`#status_${problemId}_2_2`).should("contain", "correct");
+    cy.get(`#status_${problemId}_3_1`).should("contain", "correct");
+    cy.get(`#status_${problemId}_3_2`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/drag_and_drop_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/drag_and_drop_spec.js
@@ -1,0 +1,66 @@
+// LMS Drag And Drop Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Drag And Drop Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("dragAndDrop");
+  const problem = getProblem(section, "dragAndDrop");
+  const problemId = getXblockId(problem);
+  const dragTo = (number, x, y, isFirst = true) => {
+    cy.get(
+      `.problem > div:nth-child(1) > div:nth-child(1) >
+      span:nth-child(${isFirst ? 6 : 7}) > div:nth-child(3) >
+      div:nth-child(2) > div:nth-child(2) > div:nth-child(1) >
+      div:nth-child(${number}) > div:nth-child(1)`
+    ).trigger("mousedown", { which: 1 });
+    cy.get(".base_image_container img")
+      [isFirst ? "first" : "last"]()
+      .trigger("mousemove", x, y, { force: true })
+      .trigger("mouseup", { which: 1, force: true });
+    cy.focused().trigger("mouseup", { which: 1, force: true }).blur();
+  };
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input answers (first image).
+    dragTo(1, 60, 160);
+    dragTo(2, 290, 100);
+    dragTo(3, 540, 100);
+    dragTo(4, 410, 100);
+    dragTo(5, 540, 130);
+    dragTo(6, 170, 100);
+    dragTo(7, 410, 160);
+    dragTo(8, 170, 160);
+    dragTo(9, 290, 130);
+    dragTo(10, 540, 160);
+    dragTo(11, 290, 160);
+    cy.get(".base_image_container img ~ div").should("have.length", 21);
+    // Input answers (second image).
+    dragTo(1, 33, 417, false);
+    dragTo(2, 130, 417, false);
+    cy.get(".base_image_container img ~ div").should("have.length", 23);
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.get(`#status_${problemId}_3_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/formula_response_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/formula_response_spec.js
@@ -1,0 +1,42 @@
+// LMS Formula Response Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Formula Response Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("formularesponse");
+  const problem = getProblem(section, "formularesponse");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input answers.
+    cy.get(`#input_${problemId}_2_1`).clear().type("(R_1*R_2)/R_3");
+    cy.get(`#input_${problemId}_3_1`).clear().type("n*x^(n-1)");
+    // Wait for front-end to process answers.
+    cy.get(`#input_${problemId}_2_1_preview`).should("contain", "3");
+    cy.get(`#input_${problemId}_3_1_preview`).should("contain", "1");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#${problemId}_2_1_status`).should("contain", "correct");
+    cy.get(`#${problemId}_3_1_status`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/image_response_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/image_response_spec.js
@@ -1,0 +1,43 @@
+// LMS Image Response Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Image Response Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("imageResponse");
+  const problem = getProblem(section, "imageResponse");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answers.
+    cy.get(`#imageinput_${problemId}_2_1`).click(400, 400);
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    // Input correct answers.
+    cy.get(`#imageinput_${problemId}_2_1`).click(400, 150);
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/js_input_response_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/js_input_response_spec.js
@@ -1,0 +1,44 @@
+// LMS JS Input Response Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS JS Input Response Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("jsinputResponse");
+  const problem = getProblem(section, "jsinputResponse");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answers.
+    cy.get(`#iframe_${problemId}_2_1`).click(118, 200);
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    // Input correct answers.
+    cy.get(`#iframe_${problemId}_2_1`).click(300, 200);
+    cy.wait(200);
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/latex_problem_hint_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/latex_problem_hint_spec.js
@@ -1,0 +1,43 @@
+// LMS LaTeX Problem With Hint Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS LaTeX Problem With Hint Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("problemWithHintInLatex");
+  const problem = getProblem(section, "problemWithHintInLatex");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answer.
+    cy.get(`#input_${problemId}_2_1`).clear().type("java");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    // Input correct answer.
+    cy.get(`#input_${problemId}_2_1`).clear().type("python");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/latex_problem_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/latex_problem_spec.js
@@ -1,0 +1,64 @@
+// LMS LaTeX Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS LaTeX Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("latexProblem");
+  const problem = getProblem(section, "latexProblem");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input answers.
+    // Option Problem.
+    cy.get(`#input_${problemId}_2_1`).select("India");
+    // Multiple Choice Problem.
+    const indonesiaInput = `#input_${problemId}_3_1_choice_indonesia`;
+    cy.get(indonesiaInput).check();
+    // Math Expression Problem.
+    cy.get(`#input_${problemId}_4_1`).clear().type("m*c^2");
+    cy.get(`#display_${problemId}_4_1`).should("contain", "2");
+    // Numerical Problem.
+    cy.get(`#input_${problemId}_5_1`).clear().type("0.52");
+    // Fill-in-the-Blank Problem.
+    cy.get(`#input_${problemId}_6_1`).clear().type("Nanjing University");
+    // Custom Python evaluated Problem.
+    cy.get(`#input_${problemId}_7_1`).clear().type("3");
+    cy.get(`#input_${problemId}_7_2`).clear().type("7");
+    cy.get(`#input_${problemId}_8_1`).clear().type("11");
+    cy.get(`#input_${problemId}_8_2`).clear().type("9");
+    // Image Mapped Input Problem.
+    cy.get(`#imageinput_${problemId}_9_1`).click(400, 150);
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.get(`${indonesiaInput} + span`).should("contain", "correct");
+    cy.get(`#status_${problemId}_4_1`).should("contain", "correct");
+    cy.get(`#status_${problemId}_5_1`).should("contain", "correct");
+    cy.get(`#status_${problemId}_6_1`).should("contain", "correct");
+    cy.get(`#status_${problemId}_7_1`).should("contain", "correct");
+    cy.get(`#status_${problemId}_7_2`).should("contain", "correct");
+    cy.get(`#status_${problemId}_8_1`).should("contain", "correct");
+    cy.get(`#status_${problemId}_8_2`).should("contain", "correct");
+    cy.get(`#status_${problemId}_9_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/multiple_choice_hint_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/multiple_choice_hint_spec.js
@@ -1,0 +1,61 @@
+// LMS Multiple Choice With Hint Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Multiple Choice With Hint Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("multiplechoiceHint");
+  const problem = getProblem(section, "multiplechoiceHint");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answer.
+    cy.get(`#input_${problemId}_2_1_choice_0`).check();
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(".hint-label").should("contain", "Incorrect");
+    // Input correct answer.
+    cy.get(`#input_${problemId}_2_1_choice_2`).check();
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(".hint-label").should("contain", "Correct");
+    // Ask for a first hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (1 sur 2) :");
+    // Ask for a second hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (2 sur 2) :");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log feedback_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.feedback_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log demandhint_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.demandhint_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/multiple_choice_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/multiple_choice_spec.js
@@ -1,0 +1,44 @@
+// LMS Multiple Choice Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Multiple Choice Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("multiplechoice");
+  const problem = getProblem(section, "multiplechoice");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answer.
+    cy.get(`#input_${problemId}_2_1_choice_brazil`).check();
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(".hint-label").should("contain", "Incorrect");
+    // Input correct answer.
+    const indonesiaInput = `#input_${problemId}_2_1_choice_indonesia`;
+    cy.get(indonesiaInput).check();
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`${indonesiaInput} + span`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/numerical_response_hint_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/numerical_response_hint_spec.js
@@ -1,0 +1,59 @@
+// LMS Numerical Response With Hint Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Numerical Response With Hint Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("numericalresponseHint");
+  const problem = getProblem(section, "numericalresponseHint");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answers.
+    cy.get(`#input_${problemId}_2_1`).clear().type("10000");
+    // Wait for front-end to process answers.
+    cy.get(`#input_${problemId}_2_1_preview`).should("contain", "10000");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#${problemId}_2_1_status`).should("contain", "incorrect");
+    // Ask for a first hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (1 sur 2) :");
+    // Ask for a second hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (2 sur 2) :");
+    // Input correct answer.
+    cy.get(`#input_${problemId}_2_1`).clear().type("4");
+    // Wait for front-end to process answers.
+    cy.get(`#input_${problemId}_2_1_preview`).should("contain", "4");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#${problemId}_2_1_status`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log demandhint_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.demandhint_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/numerical_response_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/numerical_response_spec.js
@@ -1,0 +1,42 @@
+// LMS Numerical Response Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Numerical Response Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("numericalresponse");
+  const problem = getProblem(section, "numericalresponse");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input answers.
+    cy.get(`#input_${problemId}_2_1`).clear().type("10000");
+    cy.get(`#input_${problemId}_3_1`).clear().type("10*i");
+    // Wait for front-end to process answers.
+    cy.get(`#input_${problemId}_2_1_preview`).should("contain", "10000");
+    cy.get(`#input_${problemId}_3_1_preview`).should("contain", "10⋅i");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#${problemId}_2_1_status`).should("contain", "incorrect");
+    cy.get(`#${problemId}_3_1_status`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/option_response_hint_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/option_response_hint_spec.js
@@ -1,0 +1,61 @@
+// LMS Option Response With Hint Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Option Response With Hint Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("optionresponseHint");
+  const problem = getProblem(section, "optionresponseHint");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Ask for a first hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (1 sur 2) :");
+    // Ask for a second hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (2 sur 2) :");
+    // Input wrong answer.
+    cy.get(`#input_${problemId}_2_1`).select("apple");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`.hint-label`).should("contain", "Incorrect");
+    // Input correct answers.
+    cy.get(`#input_${problemId}_2_1`).select("potato");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`.hint-label`).should("contain", "Correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log feedback_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.feedback_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log demandhint_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.demandhint_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/option_response_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/option_response_spec.js
@@ -1,0 +1,43 @@
+// LMS Option Response Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS Option Response Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("optionresponse");
+  const problem = getProblem(section, "optionresponse");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answer.
+    cy.get(`#input_${problemId}_2_1`).select("China");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    // Input correct answers.
+    cy.get(`#input_${problemId}_2_1`).select("India");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/string_response_hint_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/string_response_hint_spec.js
@@ -1,0 +1,61 @@
+// LMS String Response With Hint Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS String Response With Hint Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("stringResponseHint");
+  const problem = getProblem(section, "stringResponseHint");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answers.
+    cy.get(`#input_${problemId}_2_1`).clear().type("Texas");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    // Ask for a first hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (1 sur 2) :");
+    // Ask for a second hint.
+    cy.get(".hint-button").click();
+    cy.get(".problem-hint").should("contain", "Indice (2 sur 2) :");
+    // Input correct answer.
+    cy.get(`#input_${problemId}_2_1`).clear().type("Alaska");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log demandhint_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.demandhint_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log feedback_displayed server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    const eventType = "edx.problem.hint.feedback_displayed";
+    cy.graylogPartialMatch({ context, event_type: eventType });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/integration/lms_problem_interaction/string_response_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/string_response_spec.js
@@ -1,0 +1,43 @@
+// LMS String Response Problem Interaction Test
+
+import { getProblem, getSectionAndURL, getXblockId } from "../../support/utils";
+
+describe("LMS String Response Problem Interaction Test", () => {
+  const [section, sectionUrl] = getSectionAndURL("stringResponseHint");
+  const problem = getProblem(section, "stringResponseHint");
+  const problemId = getXblockId(problem);
+
+  before(() => {
+    cy.lmsLoginStudent();
+    cy.lmsEnroll(true);
+    // Navigate to the courseware.
+    cy.visit(sectionUrl);
+    // Input wrong answers.
+    cy.get(`#input_${problemId}_2_1`).clear().type("Not Nanjing University");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "incorrect");
+    // Input correct answer.
+    cy.get(`#input_${problemId}_2_1`).clear().type("Nanjing University");
+    // Submit answer.
+    cy.get(".check.Valider").click();
+    cy.get(".check.Valider").should("not.have.class", "is-disabled");
+    cy.get(`#status_${problemId}_2_1`).should("contain", "correct");
+    cy.lmsEnroll(false);
+  });
+
+  it("should log problem_check server event", () => {
+    const context = { module: { usage_key: problem.locator } };
+    cy.graylogPartialMatch({ context, event_type: "problem_check" });
+  });
+
+  it("should log problem_check browser event", () => {
+    const partial = { event_source: "browser", event_type: "problem_check" };
+    cy.graylogPartialMatch(partial);
+  });
+
+  it("should log problem_graded browser event", () => {
+    cy.graylogPartialMatch({ event_type: "problem_graded" });
+  });
+});

--- a/e2e/cypress/support/utils.js
+++ b/e2e/cypress/support/utils.js
@@ -74,5 +74,32 @@ const isSubset = (superObj, subObj) => {
   });
 };
 
+const getProblem = (section, problemName, unitName = null) => {
+  unitName = unitName || problemName;
+  return section.vertical[unitName].problem[problemName];
+};
+
+const getSectionAndURL = (
+  sectionName,
+  chapterName = "demoChapter1",
+  courseName = "demoCourse1"
+) => {
+  const course = Cypress.env("EDX_COURSES")[courseName];
+  const chapter = course.chapter[chapterName];
+  const section = chapter.sequential[sectionName];
+  const { courseId } = course;
+  const chapterId = getXblockId(chapter);
+  const sectionId = getXblockId(section);
+  const sectionUrl = `/courses/${courseId}/courseware/${chapterId}/${sectionId}/`;
+  return [section, sectionUrl];
+};
+
+const getXblockId = (xBlock) => {
+  return xBlock.locator.slice(-32);
+};
+
 module.exports.HttpWrapper = HttpWrapper;
 module.exports.isSubset = isSubset;
+module.exports.getSectionAndURL = getSectionAndURL;
+module.exports.getProblem = getProblem;
+module.exports.getXblockId = getXblockId;


### PR DESCRIPTION
### Purpose

We want to generate problem interaction edX events for most problem types.

### Proposal

Generate the following edX events:

- [x] problem_check for numericalresponse
- [x] problem_check for checkboxes_response_hint
- [x] problem_check for checkboxes_response
- [x] problem_check for circuitschematic
- [x] problem_check for customgrader
- [x] problem_check for drag_and_drop
- [x] problem_check for formularesponse
- [x] problem_check for imageresponse
- [x] problem_check for jsinput_response
- [x] problem_check for latex_problem
- [x] problem_check for multiplechoice_hint
- [x] problem_check for multiplechoice
- [x] problem_check for numericalresponse_hint
- [x] problem_check for optionresponse_hint
- [x] problem_check for optionresponse
- [x] problem_check for problem_with_hint_in_latex
- [x] ~problem_check for problem_with_hint~ (same as problem_with_hint_in_latex)
- [x] problem_check for string_response_hint
- [x] problem_check for string_response