### PR TITLE
🔨(project) bind edx sources to host directories

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,6 @@ node_modules
 
 e2e/cypress/screenshots
 e2e/cypress/videos
+
+# Don't lint edX sources
+edx/

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,9 @@ e2e/edx_courses_config.json
 # JS dependencies
 node_modules
 
+# EdX src and modules
+edx/src
+edx/modules/
+
 # logs
 yarn-error.log

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,18 @@ e2e/data/video.mp4:  ## generate a 5 second long video and put it in e2e/data di
 		-vcodec libx264 -preset superfast -tune zerolatency -pix_fmt yuv420p -t 5 \
 		-movflags +faststart "/e2e/data/video.mp4"
 
+edx/src:  ## directory to mount named bind volume for the edX-platform sources
+	mkdir -p edx/src
+
+edx/modules:  ## directory to mound named bind volume for the edX python modules
+	mkdir -p edx/modules
+
 # Make commands
 
 bootstrap: ## bootstrap the project
 bootstrap: \
+	edx/src \
+	edx/modules \
 	migrate \
 	run \
 	realm

--- a/docker-compose.edx.yml
+++ b/docker-compose.edx.yml
@@ -37,11 +37,14 @@ services:
       DJANGO_SETTINGS_MODULE: lms.envs.fun.docker_run
     ports:
       - "8072:8000"
+      - "3001:3000"
     user: ${DOCKER_UID}:${DOCKER_GID}
     volumes:
       - ./data/edx/media:/edx/var/edxapp/media
       - ./data/edx/store:/edx/app/edxapp/data
       - ./edx/config:/config
+      - edx_src:/edx/app/edxapp/edx-platform
+      - edx_modules:/usr/local/src
       - ./docker/files/usr/local/bin/auth_init:/usr/local/bin/auth_init
     command: >
       python manage.py lms runserver 0.0.0.0:8000
@@ -81,3 +84,18 @@ services:
 networks:
   potsie:
     external: true
+
+volumes:
+  edx_src:
+    driver: local
+    driver_opts:
+      type: volume
+      o: bind
+      device: ./edx/src
+
+  edx_modules:
+    driver: local
+    driver_opts:
+      type: volume
+      o: bind
+      device: ./edx/modules

--- a/e2e/cypress/integration/lms_problem_interaction/drag_and_drop_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/drag_and_drop_spec.js
@@ -23,6 +23,15 @@ describe("LMS Drag And Drop Problem Interaction Test", () => {
   before(() => {
     cy.lmsLoginStudent();
     cy.lmsEnroll(true);
+    // Reset Problem
+    const { courseId } = Cypress.env("EDX_COURSES").demoCourse1;
+    const handlerURL = "handler/xmodule_handler/problem_reset";
+    const url = `/courses/${courseId}/xblock/${problem.locator}/${handlerURL}`;
+    const method = "POST";
+    const body = { id: problem.locator };
+    cy.request({ url, method, body }).then((response) => {
+      expect(response.status).to.equal(200);
+    });
     // Navigate to the courseware.
     cy.visit(sectionUrl);
     // Input answers (first image).

--- a/e2e/cypress/integration/lms_problem_interaction/js_input_response_spec.js
+++ b/e2e/cypress/integration/lms_problem_interaction/js_input_response_spec.js
@@ -12,8 +12,11 @@ describe("LMS JS Input Response Problem Interaction Test", () => {
     cy.lmsEnroll(true);
     // Navigate to the courseware.
     cy.visit(sectionUrl);
+    // Wait for iframe to become interactive.
+    cy.wait(1500);
     // Input wrong answers.
     cy.get(`#iframe_${problemId}_2_1`).click(118, 200);
+    cy.wait(200);
     // Submit answer.
     cy.get(".check.Valider").click();
     cy.get(".check.Valider").should("not.have.class", "is-disabled");


### PR DESCRIPTION
##  Purpose

During development and testing, it is convenient to inspect the edX sources.

## Proposal

- [X] Bind two Docker volumes containing the edX sources (from the `edx-platform` and the Python modules) to the host.
- [X] Bind port 3000 from the edX LMS to facilitate connecting a remote debugger for the LMS.