### PR TITLE
Improve dev XP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       - checkout
       - run:
           name: Create external potsie network
-          command: docker network create potsie
+          command: docker network create potsie_default
       - run:
           name: Bootstrap project
           command: make bootstrap

--- a/Makefile
+++ b/Makefile
@@ -109,14 +109,27 @@ migrate:  ## perform database migrations
 	$(COMPOSE_RUN) edx_cms python manage.py cms migrate
 .PHONY: migrate
 
+run: ## start graylog/keycloak services
 run: \
-  tree
-run:  ## start base services
-	$(COMPOSE) up -d graylog keycloak
-	@echo "Wait for service to be up..."
-	$(COMPOSE_RUN) dockerize -wait tcp://graylog:9000 -timeout 60s
-	$(COMPOSE_RUN) dockerize -wait tcp://keycloak:8080 -timeout 60s
+	run-keycloak \
+	run-graylog
 .PHONY: run
+
+run-graylog: \
+  tree
+run-graylog:  ## start graylog service
+	$(COMPOSE) up -d graylog
+	@echo "Wait for graylog to be up..."
+	$(COMPOSE_RUN) dockerize -wait tcp://graylog:9000 -timeout 60s
+.PHONY: run-graylog
+
+run-keycloak: \
+  tree
+run-keycloak:  ## start keycloak service
+	$(COMPOSE) up -d keycloak
+	@echo "Wait for keycloak to be up..."
+	$(COMPOSE_RUN) dockerize -wait tcp://keycloak:8080 -timeout 60s
+.PHONY: run-keycloak
 
 run-edx: \
   tree

--- a/README.md
+++ b/README.md
@@ -80,15 +80,28 @@ Generated events with end-to-end tests or with manual navigation on the LMS serv
 
 ## Keycloak
 
-The keycloak SSO service is pre-configured for the `fun-mooc` realm. Once
-started with the project's `make run`, it can be accessed at
-[http://localhost:8080](http://localhost:8080). Administrator credentials are:
-`admin:pass`.
+The keycloak SSO service is pre-configured for the `fun-mooc` realm. 
 
-For now only the `potsie` client has been configured to login to grafana (see
-the [openfun/potsie](https://github.com/openfun/potsie) project) using a
-Keycloak account (it should have been created by the `make bootstrap` command).
-You can login to grafana using the following credentials: `grafana:funfunfun`.
+Use the _ad hoc_ Make target to run the service: 
+
+```
+make run-keycloak
+```
+
+It can be accessed at `http://localhost:8080`. 
+Admin credentials are: `admin:pass`.
+
+The `potsie` client has been configured to login to `grafana` (see
+the [openfun/potsie](https://github.com/openfun/potsie) project). 
+
+Use the _ad hoc_ Make target to provision `fun-mooc` realm: 
+
+```
+make realm
+```
+
+You can now login to grafana using the following credentials:
+`grafana:funfunfun`.
 
 ## License
 

--- a/docker-compose.edx.yml
+++ b/docker-compose.edx.yml
@@ -8,7 +8,7 @@ services:
     env_file: env.d/edx
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
     networks:
-      potsie:
+      potsie_default:
         aliases:
           - edx_mysql
       default:
@@ -79,5 +79,5 @@ services:
     image: jwilder/dockerize
 
 networks:
-  potsie:
+  potsie_default:
     external: true

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - keycloak_postgres
     networks:
-      potsie:
+      potsie_default:
         aliases:
           - keycloak
       default:
@@ -24,5 +24,5 @@ services:
       default:
 
 networks:
-  potsie:
+  potsie_default:
     external: true


### PR DESCRIPTION
## Improvements for developer experience

- A dedicated Make target for Keycloak service is defined to avoid network
dependency from Edx service.
- Potsie project only uses `default` network in dev stack. To connect `playground`
services to potsie, a new defined `potsie` network is not necessary, the
`default` one from Potsie allows to connect Keycloak and edx MySQL to Grafana.
